### PR TITLE
Fix testDeductStock to link subsample instead of sample

### DIFF
--- a/src/test/java/com/researchspace/webapp/controller/StoichiometryControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/StoichiometryControllerMVCIT.java
@@ -754,9 +754,10 @@ public class StoichiometryControllerMVCIT extends API_MVC_TestBase {
     StoichiometryMoleculeUpdateDTO molUpdate = StoichiometryMapper.toUpdateDTO(molecule);
     molUpdate.setActualAmount(1.0);
     ApiSampleWithFullSubSamples sample = createBasicSampleForUser(user);
+    String subSampleGlobalId = sample.getSubSamples().get(0).getGlobalId();
     molUpdate.setInventoryLink(
         StoichiometryInventoryLinkRequest.builder()
-            .inventoryItemGlobalId(sample.getGlobalId())
+            .inventoryItemGlobalId(subSampleGlobalId)
             .build());
 
     long stoichiometryId = createdStoichiometry.getId();


### PR DESCRIPTION
## Description

Fix `StoichiometryControllerMVCIT.testDeductStock` which was failing because it linked a Sample to the stoichiometry molecule, but stock deduction only processes SubSamples. The test now links the sample's default subsample, so the deduction code path executes correctly and generates the expected Envers audit revision.

## Testing

All 20 tests in `StoichiometryControllerMVCIT` pass.