### PR TITLE
RSDEV-1126: disable move-to-iRODS/S3 for folder selection

### DIFF
--- a/src/main/java/com/researchspace/service/GroupManager.java
+++ b/src/main/java/com/researchspace/service/GroupManager.java
@@ -102,8 +102,9 @@ public interface GroupManager {
    * Disbands and removes the group only if no member of the group has logged in within the last
    * year. Members with a null {@code lastLogin} are treated as never-logged-in (allowed).
    *
-   * <p>This method is intended for use by sysadmins to remove groups that are no longer active, without risking deleting groups
-   * that are still in use. It is not intended for regular use by non-sysadmin users
+   * <p>This method is intended for use by sysadmins to remove groups that are no longer active,
+   * without risking deleting groups that are still in use. It is not intended for regular use by
+   * non-sysadmin users
    *
    * @param groupId id of the group to delete
    * @param subject the subject performing the deletion (must already be authorised by the caller)

--- a/src/main/java/com/researchspace/service/impl/FilestoreWriteManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/FilestoreWriteManagerImpl.java
@@ -12,6 +12,7 @@ import com.researchspace.model.netfiles.NfsAuthenticationType;
 import com.researchspace.model.netfiles.NfsFileStore;
 import com.researchspace.model.netfiles.NfsFileSystem;
 import com.researchspace.model.netfiles.NfsFileSystemOption;
+import com.researchspace.model.record.BaseRecord;
 import com.researchspace.netfiles.ApiNfsCredentials;
 import com.researchspace.netfiles.NfsClient;
 import com.researchspace.netfiles.NfsFactory;
@@ -29,6 +30,7 @@ import java.util.stream.Collectors;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.shiro.authz.AuthorizationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.stereotype.Service;
@@ -206,8 +208,25 @@ public class FilestoreWriteManagerImpl implements FilestoreWriteManager {
     Set<EcatMediaFile> filesRetrieved = new LinkedHashSet<>();
     for (Long recordId : recordIds) {
       try {
-        filesRetrieved.add(baseRecordManager.retrieveMediaFile(user, recordId));
-      } catch (ObjectRetrievalFailureException ex) {
+        BaseRecord record = baseRecordManager.get(recordId, user);
+        if (record.isFolder()) {
+          errors.addError(
+              new ObjectError(
+                  "recordIds",
+                  new String[] {"gallery.filestore.folder.upload.rejected"},
+                  null,
+                  "Cannot move folders to filestores."));
+        } else if (record.isMediaRecord()) {
+          filesRetrieved.add((EcatMediaFile) record);
+        } else {
+          errors.addError(
+              new ObjectError(
+                  "recordIds",
+                  new String[] {"gallery.filestore.not.media.file"},
+                  null,
+                  "Only media files can be moved to filestores."));
+        }
+      } catch (ObjectRetrievalFailureException | AuthorizationException ex) {
         errors.addError(new ObjectError("recordIds", ex.getMessage()));
       }
     }

--- a/src/main/resources/bundles/gallery/gallery.properties
+++ b/src/main/resources/bundles/gallery/gallery.properties
@@ -1,2 +1,4 @@
 gallery.image.label=Image
 gallery.api.no_top_level_folder=You cannot create a top-level folder in the Gallery; create folder in one of the sub-galleries, e.g.  Images, Documents
+gallery.filestore.folder.upload.rejected=Cannot move folders to filestores.
+gallery.filestore.not.media.file=Only media files can be moved to filestores.

--- a/src/main/webapp/ui/src/eln/gallery/__tests__/useGalleryListing.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/__tests__/useGalleryListing.test.tsx
@@ -281,8 +281,10 @@ describe("RemoteFile.canMoveToS3", () => {
 
 function makeLocalGalleryFile({
   isSystemFolder,
+  type = "image",
 }: {
   isSystemFolder: boolean;
+  type?: string;
 }): LocalGalleryFile {
   return new LocalGalleryFile({
     id: dummyId(),
@@ -292,7 +294,7 @@ function makeLocalGalleryFile({
     creationDate: new Date(),
     modificationDate: new Date(),
     description: new Description({ key: "empty" }),
-    type: "image",
+    type,
     isSystemFolder,
     isSharedFolder: false,
     ownerId: 1,
@@ -309,17 +311,32 @@ function makeLocalGalleryFile({
   });
 }
 
+describe("LocalGalleryFile.canMoveToIrods", () => {
+  test("returns Ok for a non-folder file", () => {
+    const file = makeLocalGalleryFile({ isSystemFolder: false });
+    expect(file.canMoveToIrods.isOk).toBe(true);
+  });
+
+  test("returns Error for a folder", () => {
+    const file = makeLocalGalleryFile({ isSystemFolder: false, type: "Folder" });
+    expect(file.canMoveToIrods.isOk).toBe(false);
+    expect(file.canMoveToIrods.orElseGet(([e]) => e)).toMatchObject({
+      message: expect.stringContaining("folder"),
+    });
+  });
+});
+
 describe("LocalGalleryFile.canMoveToS3", () => {
-  test("returns Ok for a regular (non-system) file", () => {
+  test("returns Ok for a non-folder file", () => {
     const file = makeLocalGalleryFile({ isSystemFolder: false });
     expect(file.canMoveToS3.isOk).toBe(true);
   });
 
-  test("returns Error for a system folder", () => {
-    const file = makeLocalGalleryFile({ isSystemFolder: true });
+  test("returns Error for a folder", () => {
+    const file = makeLocalGalleryFile({ isSystemFolder: false, type: "Folder" });
     expect(file.canMoveToS3.isOk).toBe(false);
     expect(file.canMoveToS3.orElseGet(([e]) => e)).toMatchObject({
-      message: expect.stringContaining("system folder"),
+      message: expect.stringContaining("folder"),
     });
   });
 });

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.tsx
@@ -504,14 +504,14 @@ export class LocalGalleryFile implements GalleryFile {
   }
 
   get canMoveToIrods(): Result<null> {
-    if (this.isSystemFolder)
-      return Result.Error([new Error("Cannot move system folders to iRODS.")]);
+    if (this.isFolder)
+      return Result.Error([new Error("Cannot move folders to iRODS.")]);
     return Result.Ok(null);
   }
 
   get canMoveToS3(): Result<null> {
-    if (this.isSystemFolder)
-      return Result.Error([new Error("Cannot move system folders to S3.")]);
+    if (this.isFolder)
+      return Result.Error([new Error("Cannot move folders to S3.")]);
     return Result.Ok(null);
   }
 

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
@@ -23,6 +23,7 @@ import com.researchspace.api.v1.model.EcatAudioFileStub;
 import com.researchspace.api.v1.model.NfsClientStub;
 import com.researchspace.model.User;
 import com.researchspace.model.netfiles.NfsFileStore;
+import com.researchspace.model.record.BaseRecord;
 import com.researchspace.model.views.CompositeRecordOperationResult;
 import com.researchspace.netfiles.ApiNfsCredentials;
 import com.researchspace.netfiles.NfsAuthentication;
@@ -101,10 +102,8 @@ class GalleryFilestoresApiControllerWriteOpsTest {
     when(nfsAuthentication.login(eq(USERNAME), eq(PASSWORD), any(), any()))
         .thenReturn(nfsClientLoggedIn);
 
-    when(baseRecordManager.retrieveMediaFile(any(), eq(123L)))
-        .thenReturn(new EcatAudioFileStub(1L, "file1.wav"));
-    when(baseRecordManager.retrieveMediaFile(any(), eq(456L)))
-        .thenReturn(new EcatAudioFileStub(2L, "file2.wav"));
+    when(baseRecordManager.get(eq(123L), any())).thenReturn(new EcatAudioFileStub(1L, "file1.wav"));
+    when(baseRecordManager.get(eq(456L), any())).thenReturn(new EcatAudioFileStub(2L, "file2.wav"));
 
     when(nfsManager.uploadFilesToNfs(
             anyCollection(), anyString(), any(WritableNfsClient.class), any()))
@@ -143,9 +142,9 @@ class GalleryFilestoresApiControllerWriteOpsTest {
 
   @Test
   void copyToFilestore_multipleInvalidRecordIds_allErrorsReported() {
-    when(baseRecordManager.retrieveMediaFile(any(), eq(789L)))
+    when(baseRecordManager.get(eq(789L), any()))
         .thenThrow(new ObjectRetrievalFailureException("EcatMediaFile", "789"));
-    when(baseRecordManager.retrieveMediaFile(any(), eq(987L)))
+    when(baseRecordManager.get(eq(987L), any()))
         .thenThrow(new ObjectRetrievalFailureException("EcatMediaFile", "987"));
     ApiGalleryFilestoreOperationRequest request =
         new ApiGalleryFilestoreOperationRequest(
@@ -503,5 +502,51 @@ class GalleryFilestoresApiControllerWriteOpsTest {
         srcId, request, new BeanPropertyBindingResult(request, "request"), user);
 
     verify(srcClient).deleteFile("src-root/file.png");
+  }
+
+  @Test
+  void copyToFilestore_folderRecordId_throwsBindException() {
+    Long folderId = 999L;
+    BaseRecord folderMock = mock(BaseRecord.class);
+    when(folderMock.isFolder()).thenReturn(true);
+    when(baseRecordManager.get(eq(folderId), any())).thenReturn(folderMock);
+    ApiGalleryFilestoreOperationRequest request =
+        new ApiGalleryFilestoreOperationRequest(
+            Set.of(folderId), new ApiNfsCredentials(null, USERNAME, PASSWORD));
+
+    BindException ex =
+        assertThrows(
+            BindException.class,
+            () ->
+                controller.copyToFilestore(
+                    validFilestorePathId,
+                    request,
+                    new BeanPropertyBindingResult(request, "request"),
+                    user));
+
+    assertEquals(1, ex.getAllErrors().size());
+  }
+
+  @Test
+  void moveToFilestore_folderRecordId_throwsBindException() {
+    Long folderId = 999L;
+    BaseRecord folderMock = mock(BaseRecord.class);
+    when(folderMock.isFolder()).thenReturn(true);
+    when(baseRecordManager.get(eq(folderId), any())).thenReturn(folderMock);
+    ApiGalleryFilestoreOperationRequest request =
+        new ApiGalleryFilestoreOperationRequest(
+            Set.of(folderId), new ApiNfsCredentials(null, USERNAME, PASSWORD));
+
+    BindException ex =
+        assertThrows(
+            BindException.class,
+            () ->
+                controller.moveToFilestore(
+                    validFilestorePathId,
+                    request,
+                    new BeanPropertyBindingResult(request, "request"),
+                    user));
+
+    assertEquals(1, ex.getAllErrors().size());
   }
 }


### PR DESCRIPTION
## Description

- **Frontend:** `LocalGalleryFile.canMoveToIrods` and `canMoveToS3` previously only checked `isSystemFolder`; updated to check `isFolder` so that all folder types (including user-created ones) are blocked from move-to-filestore actions in the Gallery UI.
- **Backend:** `FilestoreWriteManagerImpl.retrieveMediaFiles()` now explicitly pre-checks each record with `baseRecordManager.get()` and rejects folders with a bundle-keyed validation error before attempting any filestore operation.

## Design decisions

- Used `baseRecordManager.get(recordId, user)` (rather than the media-file-specific retrieval path) so that the folder check works for all record types and produces a clear, i18n-safe `BindException` rather than a confusing downstream error.
- Error messages use Spring `ObjectError` with message bundle codes (`gallery.filestore.folder.upload.rejected`, `gallery.filestore.not.media.file`) per the project i18n rule in CLAUDE.md.

## Testing

- Frontend: 10 Vitest tests covering `canMoveToIrods` and `canMoveToS3` for both `LocalGalleryFile` and `RemoteFile`, including folder and non-folder cases.
- Backend: 18 JUnit 5 tests in `GalleryFilestoresApiControllerWriteOpsTest`, including two new tests (`copyToFilestore_folderRecordId_throwsBindException`, `moveToFilestore_folderRecordId_throwsBindException`) covering the folder rejection path.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)